### PR TITLE
Potential fix for code scanning alert no. 27: Missing rate limiting

### DIFF
--- a/backend/routes/journal.route.js
+++ b/backend/routes/journal.route.js
@@ -19,7 +19,7 @@ const router = express.Router();
 
 // Journal CRUD (all require authentication)
 router.post("/", authMiddleware, validateJournal, journalAILimiter, createJournal);
-router.get("/", authMiddleware, listJournals);
+router.get("/", authMiddleware, journalAILimiter, listJournals);
 router.get("/stats", authMiddleware, getJournalStats); // Must come before /:id
 router.get("/:id", authMiddleware, getJournal);
 router.get("/:id/insights", authMiddleware, getJournalInsights);


### PR DESCRIPTION
Potential fix for [https://github.com/Rushorgir/Zenly/security/code-scanning/27](https://github.com/Rushorgir/Zenly/security/code-scanning/27)

The best way to fix the problem is to add middleware that limits the rate of requests to the affected route. In this code, the `journalAILimiter` middleware is already imported and applied to other routes, but not to the `listJournals` route. Assuming this limiter is a generic rate limiter meant for journal-related endpoints, we should add it to the `GET "/"` route.

- **How**: Add `journalAILimiter` as a middleware to the `router.get("/", ...)` route, as is done for other expensive routes.
- **Where**: Only change the router line for `GET /` in the `backend/routes/journal.route.js` file.
- **What is needed**: No new imports or function definitions are needed, only an additional middleware added in the relevant line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
