### PR TITLE
Potential fix for code scanning alert no. 123: Use of externally-controlled format string

### DIFF
--- a/backend/services/streaming.service.js
+++ b/backend/services/streaming.service.js
@@ -266,7 +266,7 @@ class StreamingService {
       console.log(`[Streaming] Journal analysis stream completed: ${streamId}`);
 
     } catch (error) {
-      console.error(`[Streaming] Journal analysis error: ${streamId}`, error);
+      console.error('[Streaming] Journal analysis error: %s', streamId, error);
       
       this.sendEvent(res, 'error', {
         error: error.message,


### PR DESCRIPTION
Potential fix for [https://github.com/Rushorgir/Zenly/security/code-scanning/123](https://github.com/Rushorgir/Zenly/security/code-scanning/123)

The best way to fix this problem is to avoid embedding user-controlled data directly into the format string for `console.error` (or `console.log`). Instead, use a static format string with `%s` as a placeholder and pass the variable as a separate argument, ensuring that any user input cannot be interpreted as a format specifier. This requires changing line 269 in `backend/services/streaming.service.js` to use `console.error('[Streaming] Journal analysis error: %s', streamId, error);` instead of the template literal, and similarly for any other logging statements that embed `streamId` or `journalId` directly into format strings.

No additional imports or package installations are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
